### PR TITLE
Use python's next & explicit iterator to find the correct filename

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -17,8 +17,9 @@ files = []
 # Fetching filelist and finding the latest records
 print("Fetching records...")
 ftp.retrlines('NLST', lambda fn: files.append(fn))
-postcodes_filename = str(next(filter(lambda file: 'PCF' in file, files)))
 
+files_iter = iter(files)
+postcodes_filename = next(file_name for file_name in files_iter if file_name.startswith("PCF"))
 
 # Retrieving the file
 postcode_raw_data = BytesIO()


### PR DESCRIPTION
Was throwing `TypeError: list object is not an iterator` with python 2.7.10. Fixes it and simplifies the code a bit.
